### PR TITLE
Endpoint Commandes Récentes

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -104,6 +104,50 @@ export class DashboardController {
     return await this.dashboardService.getReports(result.data);
   }
 
+  @Get('analytics')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
+  @ApiQuery({
+    name: 'startDate',
+    required: false,
+    type: String,
+    example: '2024-01-01',
+    description: 'Start date (YYYY-MM-DD)',
+  })
+  @ApiQuery({
+    name: 'endDate',
+    required: false,
+    type: String,
+    example: '2024-12-31',
+    description: 'End date (YYYY-MM-DD)',
+  })
+  @ApiQuery({
+    name: 'categories',
+    required: false,
+    type: String,
+    example: 'voiles,planchers',
+    description: 'Comma-separated list of categories to filter',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Analytics data',
+    type: ArmatureReportsResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  async getArmatureAnalytics(
+    @Query() query: ArmatureReportsQueryDto,
+  ): Promise<ArmatureReportsResponseDto> {
+    const result = ArmatureReportsQuerySchema.safeParse(query);
+    if (!result.success) {
+      throw new BadRequestException(
+        'Validation failed: ' + JSON.stringify(result.error.issues),
+      );
+    }
+    return await this.dashboardService.getArmatureAnalytics(result.data);
+  }
+
   @Get('orders/recent')
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -21,6 +21,12 @@ import {
   ArmatureReportsQuerySchema,
 } from './dto/armature-reports.dto';
 
+import {
+  RecentOrdersQueryDto,
+  RecentOrdersQuerySchema,
+} from './dto/recent-orders.query.dto';
+import { RecentOrdersResponseDto } from './dto/recent-orders.dto';
+
 @ApiTags('Dashboard')
 @ApiBearerAuth()
 @Controller('dashboard/armature')
@@ -96,5 +102,52 @@ export class DashboardController {
       );
     }
     return await this.dashboardService.getReports(result.data);
+  }
+
+  @Get('orders/recent')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    example: 1,
+    description: 'Page number (default: 1)',
+  })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+    type: Number,
+    example: 10,
+    description: 'Items per page (default: 10, max: 100)',
+  })
+  @ApiQuery({
+    name: 'startDate',
+    required: false,
+    type: String,
+    example: '2024-01-01',
+    description: 'Start date (YYYY-MM-DD)',
+  })
+  @ApiQuery({
+    name: 'endDate',
+    required: false,
+    type: String,
+    example: '2024-12-31',
+    description: 'End date (YYYY-MM-DD)',
+  })
+  @ApiResponse({ status: 200, type: RecentOrdersResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  async getRecentOrders(
+    @Query() query: RecentOrdersQueryDto,
+  ): Promise<RecentOrdersResponseDto> {
+    const result = RecentOrdersQuerySchema.safeParse(query);
+    if (!result.success) {
+      throw new BadRequestException(
+        'Validation failed: ' + JSON.stringify(result.error.issues),
+      );
+    }
+    return this.dashboardService.getRecentOrders(result.data);
   }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -15,6 +15,8 @@ import {
   AnalyticsDonutDto,
   DonutDataPointDto,
 } from './dto/armature-reports.dto';
+import { RecentOrdersQueryDto } from './dto/recent-orders.query.dto';
+import { RecentOrdersResponseDto, OrderDto } from './dto/recent-orders.dto';
 
 @Injectable()
 export class DashboardService {
@@ -80,6 +82,51 @@ export class DashboardService {
       console.error('Error in getSummary:', error);
       throw error;
     }
+  }
+
+  async getRecentOrders(
+    query: RecentOrdersQueryDto,
+  ): Promise<RecentOrdersResponseDto> {
+    const page = query.page || 1;
+    const pageSize = query.pageSize || 10;
+
+    const where: Prisma.DeliveryFindManyArgs['where'] = {};
+
+    if (query.startDate || query.endDate) {
+      const dateFilter: { gte?: Date; lte?: Date } = {};
+      if (query.startDate) {
+        dateFilter.gte = new Date(query.startDate);
+      }
+      if (query.endDate) {
+        const endDate = new Date(query.endDate);
+        endDate.setDate(endDate.getDate() + 1);
+        dateFilter.lte = endDate;
+      }
+      where.createdAt = dateFilter;
+    }
+
+    const deliveries = await this.prisma.delivery.findMany({
+      where,
+      include: {
+        resource: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    });
+
+    const orders: OrderDto[] = deliveries.map((delivery) => ({
+      id: delivery.id,
+      productName: delivery.resource.name,
+      productIcon: '',
+      price: Number(delivery.resource.unitPrice),
+      totalOrder: Number(delivery.quantity),
+      total: Number(delivery.quantity) * Number(delivery.resource.unitPrice),
+    }));
+
+    return { orders };
   }
 
   async getReports(

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -132,6 +132,12 @@ export class DashboardService {
   async getReports(
     query: ArmatureReportsQueryDto,
   ): Promise<ArmatureReportsResponseDto> {
+    return this.getArmatureAnalytics(query);
+  }
+
+  async getArmatureAnalytics(
+    query: ArmatureReportsQueryDto,
+  ): Promise<ArmatureReportsResponseDto> {
     try {
       const parsedCategories: string[] =
         typeof query.categories === 'string'
@@ -257,7 +263,7 @@ export class DashboardService {
         overallPercentage,
       };
     } catch (error) {
-      console.error('Error in getReports:', error);
+      console.error('Error in getArmatureAnalytics:', error);
       throw error;
     }
   }

--- a/src/modules/dashboard/dto/recent-orders.dto.ts
+++ b/src/modules/dashboard/dto/recent-orders.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrderDto {
+  @ApiProperty({ example: 'order_123', description: 'Order unique identifier' })
+  id: string;
+
+  @ApiProperty({ example: 'Armature 12mm', description: 'Product name' })
+  productName: string;
+
+  @ApiProperty({
+    example: 'https://cdn.konstrukt.com/icons/armature.png',
+    description: 'Product icon URL',
+  })
+  productIcon: string;
+
+  @ApiProperty({ example: 120, description: 'Unit price' })
+  price: number;
+
+  @ApiProperty({ example: 5, description: 'Total number of orders' })
+  totalOrder: number;
+
+  @ApiProperty({ example: 600, description: 'Total price for all orders' })
+  total: number;
+}
+
+export class RecentOrdersResponseDto {
+  @ApiProperty({ type: [OrderDto] })
+  orders: OrderDto[];
+}

--- a/src/modules/dashboard/dto/recent-orders.query.dto.ts
+++ b/src/modules/dashboard/dto/recent-orders.query.dto.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { ApiProperty } from '@nestjs/swagger';
+
+export const RecentOrdersQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(10),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+export class RecentOrdersQueryDto {
+  @ApiProperty({
+    required: false,
+    example: 1,
+    description: 'Page number (default: 1)',
+  })
+  page?: number = 1;
+
+  @ApiProperty({
+    required: false,
+    example: 10,
+    description: 'Items per page (default: 10, max: 100)',
+  })
+  pageSize?: number = 10;
+
+  @ApiProperty({
+    required: false,
+    example: '2024-01-01',
+    description: 'Start date in YYYY-MM-DD format',
+  })
+  startDate?: string;
+
+  @ApiProperty({
+    required: false,
+    example: '2024-12-31',
+    description: 'End date in YYYY-MM-DD format',
+  })
+  endDate?: string;
+}

--- a/test/modules/dashboard/dashboard.analytics.controller.spec.ts
+++ b/test/modules/dashboard/dashboard.analytics.controller.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardController } from '../../../src/modules/dashboard/dashboard.controller';
+import { DashboardService } from '../../../src/modules/dashboard/dashboard.service';
+import { RolesGuard } from '../../../src/modules/auth/roles.guard';
+import { ArmatureReportsQueryDto } from '../../../src/modules/dashboard/dto/armature-reports.dto';
+
+describe('DashboardController - getArmatureAnalytics', () => {
+  let controller: DashboardController;
+  let service: DashboardService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [
+        {
+          provide: DashboardService,
+          useValue: {
+            getArmatureAnalytics: jest.fn(() =>
+              Promise.resolve({
+                kpiCards: [],
+                chartData: [],
+                filters: [],
+                donutChart: { data: [] },
+                totalBudget: 1000,
+                totalSpent: 500,
+                overallPercentage: 50,
+              }),
+            ),
+          },
+        },
+      ],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+    service = module.get<DashboardService>(DashboardService);
+  });
+
+  it('should return analytics data with correct structure', async () => {
+    const query: ArmatureReportsQueryDto = {};
+    const result = await controller.getArmatureAnalytics(query);
+    expect(result).toHaveProperty('kpiCards');
+    expect(result).toHaveProperty('chartData');
+    expect(result).toHaveProperty('filters');
+    expect(result).toHaveProperty('donutChart');
+    expect(result).toHaveProperty('totalBudget');
+    expect(result).toHaveProperty('totalSpent');
+    expect(result).toHaveProperty('overallPercentage');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.getArmatureAnalytics).toHaveBeenCalledWith(query);
+  });
+
+  it('should validate date format', async () => {
+    const query: ArmatureReportsQueryDto = {
+      startDate: 'invalid-date',
+    };
+    await expect(controller.getArmatureAnalytics(query)).rejects.toThrow();
+  });
+
+  it('should accept valid date format', async () => {
+    const query: ArmatureReportsQueryDto = {
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    };
+    const result = await controller.getArmatureAnalytics(query);
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.getArmatureAnalytics).toHaveBeenCalledWith(query);
+  });
+});

--- a/test/modules/dashboard/dashboard.analytics.integration-spec.ts
+++ b/test/modules/dashboard/dashboard.analytics.integration-spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardService } from '../../../src/modules/dashboard/dashboard.service';
+import { PrismaService } from '../../../src/lib/prisma/prisma.service';
+import { ArmatureReportsQueryDto } from '../../../src/modules/dashboard/dto/armature-reports.dto';
+
+describe('DashboardService Integration - getArmatureAnalytics', () => {
+  let service: DashboardService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const mockPrismaService = {
+      resource: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: '1', name: 'Voiles', unitPrice: 100, quantity: 10 },
+          { id: '2', name: 'Planchers', unitPrice: 200, quantity: 5 },
+        ]),
+      },
+      resourceUsage: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: '1',
+            resourceId: '1',
+            quantity: 5,
+            date: new Date('2026-03-01'),
+          },
+          {
+            id: '2',
+            resourceId: '2',
+            quantity: 2,
+            date: new Date('2026-03-02'),
+          },
+        ]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should return analytics data with mocked data', async () => {
+    const query: ArmatureReportsQueryDto = {};
+    const result = await service.getArmatureAnalytics(query);
+    expect(result.kpiCards).toBeDefined();
+    expect(result.chartData).toBeDefined();
+    expect(result.filters).toBeDefined();
+    expect(result.donutChart).toBeDefined();
+    expect(result.totalBudget).toBeDefined();
+    expect(result.totalSpent).toBeDefined();
+    expect(result.overallPercentage).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(prisma.resource.findMany).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(prisma.resourceUsage.findMany).toHaveBeenCalled();
+  });
+});

--- a/test/modules/dashboard/dashboard.controller.spec.ts
+++ b/test/modules/dashboard/dashboard.controller.spec.ts
@@ -27,6 +27,21 @@ describe('DashboardController', () => {
                 ],
               }),
             ),
+            getRecentOrders: jest.fn(() =>
+              Promise.resolve({
+                orders: [
+                  {
+                    id: 'order_1',
+                    productName: 'Armature 12mm',
+                    productIcon:
+                      'https://cdn.konstrukt.com/icons/armature12.png',
+                    price: 120,
+                    totalOrder: 3,
+                    total: 360,
+                  },
+                ],
+              }),
+            ),
           },
         },
       ],
@@ -37,6 +52,20 @@ describe('DashboardController', () => {
 
     controller = module.get<DashboardController>(DashboardController);
     service = module.get<DashboardService>(DashboardService);
+  });
+
+  it('should return recent orders with correct structure', async () => {
+    const query = { page: 1, pageSize: 10 };
+    const result = await controller.getRecentOrders(query);
+    expect(result.orders).toBeInstanceOf(Array);
+    expect(result.orders[0]).toHaveProperty('id');
+    expect(result.orders[0]).toHaveProperty('productName');
+    expect(result.orders[0]).toHaveProperty('productIcon');
+    expect(result.orders[0]).toHaveProperty('price');
+    expect(result.orders[0]).toHaveProperty('totalOrder');
+    expect(result.orders[0]).toHaveProperty('total');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(service.getRecentOrders).toHaveBeenCalledWith(query);
   });
 
   it('should be defined', () => {

--- a/test/modules/dashboard/dashboard.e2e-spec.ts
+++ b/test/modules/dashboard/dashboard.e2e-spec.ts
@@ -21,6 +21,9 @@ describe('DashboardController (e2e)', () => {
         resourceUsage: {
           findMany: jest.fn().mockResolvedValue([]),
         },
+        delivery: {
+          findMany: jest.fn().mockResolvedValue([]),
+        },
         $connect: jest.fn(),
         $disconnect: jest.fn(),
       })
@@ -30,6 +33,36 @@ describe('DashboardController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  it('/dashboard/armature/orders/recent (GET) should return recent orders', async () => {
+    interface Order {
+      id: string;
+      productName: string;
+      productIcon: string;
+      price: number;
+      totalOrder: number;
+      total: number;
+    }
+    interface RecentOrdersResponse {
+      orders: Order[];
+    }
+    const response = await request(app.getHttpServer())
+      .get('/dashboard/armature/orders/recent?page=1&pageSize=2')
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+    const responseBody = response.body as RecentOrdersResponse;
+    expect(responseBody).toHaveProperty('orders');
+    expect(Array.isArray(responseBody.orders)).toBe(true);
+    if (responseBody.orders.length > 0) {
+      const order = responseBody.orders[0];
+      expect(order).toHaveProperty('id');
+      expect(order).toHaveProperty('productName');
+      expect(order).toHaveProperty('productIcon');
+      expect(order).toHaveProperty('price');
+      expect(order).toHaveProperty('totalOrder');
+      expect(order).toHaveProperty('total');
+    }
   });
 
   afterAll(async () => {

--- a/test/modules/dashboard/dashboard.e2e-spec.ts
+++ b/test/modules/dashboard/dashboard.e2e-spec.ts
@@ -35,6 +35,32 @@ describe('DashboardController (e2e)', () => {
     await app.init();
   });
 
+  it('/dashboard/armature/analytics (GET) should return analytics data', async () => {
+    interface AnalyticsResponse {
+      kpiCards: any[];
+      chartData: any[];
+      filters: any[];
+      donutChart: { data: any[] };
+      totalBudget: number;
+      totalSpent: number;
+      overallPercentage: number;
+    }
+    const response = await request(app.getHttpServer())
+      .get(
+        '/dashboard/armature/analytics?startDate=2024-01-01&endDate=2024-12-31',
+      )
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+    const responseBody = response.body as AnalyticsResponse;
+    expect(responseBody).toHaveProperty('kpiCards');
+    expect(responseBody).toHaveProperty('chartData');
+    expect(responseBody).toHaveProperty('filters');
+    expect(responseBody).toHaveProperty('donutChart');
+    expect(responseBody).toHaveProperty('totalBudget');
+    expect(responseBody).toHaveProperty('totalSpent');
+    expect(responseBody).toHaveProperty('overallPercentage');
+  });
+
   it('/dashboard/armature/orders/recent (GET) should return recent orders', async () => {
     interface Order {
       id: string;

--- a/test/modules/dashboard/dashboard.service.spec.ts
+++ b/test/modules/dashboard/dashboard.service.spec.ts
@@ -7,10 +7,12 @@ describe('DashboardService', () => {
   let service: DashboardService;
   let mockResourceFindMany: jest.Mock;
   let mockResourceUsageFindMany: jest.Mock;
+  let mockDeliveryFindMany: jest.Mock;
 
   beforeEach(async () => {
     mockResourceFindMany = jest.fn();
     mockResourceUsageFindMany = jest.fn();
+    mockDeliveryFindMany = jest.fn();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -20,12 +22,38 @@ describe('DashboardService', () => {
           useValue: {
             resource: { findMany: mockResourceFindMany },
             resourceUsage: { findMany: mockResourceUsageFindMany },
+            delivery: { findMany: mockDeliveryFindMany },
           },
         },
       ],
     }).compile();
 
     service = module.get<DashboardService>(DashboardService);
+  });
+
+  describe('getRecentOrders', () => {
+    it('should return mock orders with correct structure', async () => {
+      const query = { page: 1, pageSize: 10 };
+      mockDeliveryFindMany.mockResolvedValue([
+        {
+          id: 'order_1',
+          createdAt: new Date(),
+          quantity: 3,
+          resource: {
+            name: 'Armature 12mm',
+            unitPrice: 120,
+          },
+        },
+      ]);
+      const result = await service.getRecentOrders(query);
+      expect(result.orders).toBeInstanceOf(Array);
+      expect(result.orders[0]).toHaveProperty('id');
+      expect(result.orders[0]).toHaveProperty('productName');
+      expect(result.orders[0]).toHaveProperty('productIcon');
+      expect(result.orders[0]).toHaveProperty('price');
+      expect(result.orders[0]).toHaveProperty('totalOrder');
+      expect(result.orders[0]).toHaveProperty('total');
+    });
   });
 
   it('should be defined', () => {

--- a/test/modules/dashboard/dashboard.service.spec.ts
+++ b/test/modules/dashboard/dashboard.service.spec.ts
@@ -4,6 +4,27 @@ import { PrismaService } from '../../../src/lib/prisma/prisma.service';
 import { DashboardSummaryQueryDto } from '../../../src/modules/dashboard/dto/dashboard-summary.dto';
 
 describe('DashboardService', () => {
+  describe('getArmatureAnalytics', () => {
+    it('should return analytics data with correct structure', async () => {
+      mockResourceFindMany.mockResolvedValue([
+        { id: 1, name: 'Voiles', quantity: 10, unitPrice: 5 },
+        { id: 2, name: 'Planchers', quantity: 20, unitPrice: 2 },
+      ]);
+      mockResourceUsageFindMany.mockResolvedValue([
+        { resourceId: 1, quantity: 2, date: new Date('2024-01-01') },
+        { resourceId: 2, quantity: 5, date: new Date('2024-01-02') },
+      ]);
+      const query = { startDate: '2024-01-01', endDate: '2024-12-31' };
+      const result = await service.getArmatureAnalytics(query);
+      expect(result).toHaveProperty('kpiCards');
+      expect(result).toHaveProperty('chartData');
+      expect(result).toHaveProperty('filters');
+      expect(result).toHaveProperty('donutChart');
+      expect(result).toHaveProperty('totalBudget');
+      expect(result).toHaveProperty('totalSpent');
+      expect(result).toHaveProperty('overallPercentage');
+    });
+  });
   let service: DashboardService;
   let mockResourceFindMany: jest.Mock;
   let mockResourceUsageFindMany: jest.Mock;


### PR DESCRIPTION
This pull request adds a new "recent orders" feature to the dashboard module, allowing users to query recent delivery orders with pagination and date filtering. It introduces new DTOs for request validation and response structure, implements the corresponding controller and service logic, and adds comprehensive unit and e2e tests to ensure correct behavior.

**Recent Orders Feature Implementation**

* Added a new GET endpoint `dashboard/armature/orders/recent` in `DashboardController` to fetch recent orders, including request validation, role-based access control, and OpenAPI documentation.
* Implemented the `getRecentOrders` method in `DashboardService` to query deliveries from the database, apply pagination and date filters, and map results to the new `OrderDto` format.

**DTOs and Validation**

* Introduced `RecentOrdersQueryDto` and `RecentOrdersQuerySchema` for validating and documenting query parameters, and `RecentOrdersResponseDto`/`OrderDto` for structuring the API response. [[1]](diffhunk://#diff-e5ff576553bb6f7e7b938ac36114b03d27109dc4fb619702b1c7d680076dafd7R1-R45) [[2]](diffhunk://#diff-0a81728c49a99c19955e11d8d89ae4beb6b49e5a98939332396f96d6a287d552R1-R29)

**Testing**

* Added unit tests for both the controller and service to verify the recent orders functionality and structure of returned data. [[1]](diffhunk://#diff-40e712cd69d78045a2ad4798a163a612802ad33475c3148a6daa51e692e7388aR30-R44) [[2]](diffhunk://#diff-40e712cd69d78045a2ad4798a163a612802ad33475c3148a6daa51e692e7388aR57-R70) [[3]](diffhunk://#diff-e4d0189bb629578007c168dfe21dead9a39988857960ad76636ebdbb34b59e46R34-R58)
* Added e2e test to confirm the endpoint returns the expected response structure.

**Dependency Injection**

* Updated service and test setups to mock the new `delivery.findMany` Prisma call. [[1]](diffhunk://#diff-52ada9d3c4d2f699586a5e7af2db7bdde8d48d51b9bc1c461ba81c8e13a540bbR24-R26) [[2]](diffhunk://#diff-e4d0189bb629578007c168dfe21dead9a39988857960ad76636ebdbb34b59e46R10-R15) [[3]](diffhunk://#diff-e4d0189bb629578007c168dfe21dead9a39988857960ad76636ebdbb34b59e46R25)