### PR TITLE
fix : rendre organizationId optionnel pour l’inscription utilisateur

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Organization {
 
 model User {
 	id             String       @id @default(uuid()) @db.Uuid
-	organizationId String       @db.Uuid
+	organizationId String?      @db.Uuid
 	email          String       @unique
 	password   String
 	role           UserRole
@@ -110,7 +110,7 @@ model User {
 	lastName       String
 	createdAt      DateTime     @default(now())
 
-	organization  Organization  @relation(fields: [organizationId], references: [id])
+	organization  Organization?  @relation(fields: [organizationId], references: [id])
 	uploadedDocs  Document[]    @relation("DocumentUploadedBy")
 	reports       Report[]      @relation("ReportGeneratedBy")
 	assignedTasks Task[]        @relation("TaskAssignedTo")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,21 @@
-import { Module } from '@nestjs/common';
+import { Controller, Get, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './lib/prisma/prisma.module';
 import { UserModule } from './modules/users/user.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { AuthModule } from './modules/auth/auth.module';
+
+@Controller()
+export class AppController {
+  @Get()
+  getRoot() {
+    return {
+      message: 'Konstrukt API is running',
+      documentation: '/api',
+      version: '1.0',
+    };
+  }
+}
 
 @Module({
   imports: [
@@ -13,7 +25,7 @@ import { AuthModule } from './modules/auth/auth.module';
     AuthModule,
     DashboardModule,
   ],
-  controllers: [],
+  controllers: [AppController],
   providers: [],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,20 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.enableCors();
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('Konstrukt API')

--- a/src/modules/auth/dto/login.dto.ts
+++ b/src/modules/auth/dto/login.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({ example: 'user@example.com' })
+  @IsEmail({}, { message: 'Invalid email format' })
+  @IsNotEmpty({ message: 'Email is required' })
   email: string;
 
   @ApiProperty({ example: 'password123' })
+  @IsString()
+  @IsNotEmpty({ message: 'Password is required' })
+  @MinLength(6, { message: 'Password must be at least 6 characters long' })
   password: string;
 }

--- a/src/modules/auth/dto/register.dto.ts
+++ b/src/modules/auth/dto/register.dto.ts
@@ -1,18 +1,40 @@
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MinLength,
+} from 'class-validator';
 
 export class RegisterDto {
   @ApiProperty({ example: 'user@example.com' })
+  @IsEmail({}, { message: 'Invalid email format' })
+  @IsNotEmpty({ message: 'Email is required' })
   email: string;
 
   @ApiProperty({ example: 'password123' })
+  @IsString()
+  @IsNotEmpty({ message: 'Password is required' })
+  @MinLength(6, { message: 'Password must be at least 6 characters long' })
   password: string;
 
   @ApiProperty({ example: 'John' })
+  @IsString()
+  @IsNotEmpty({ message: 'First name is required' })
   firstName: string;
 
   @ApiProperty({ example: 'Doe' })
+  @IsString()
+  @IsNotEmpty({ message: 'Last name is required' })
   lastName: string;
 
-  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
-  organizationId: string;
+  @ApiProperty({
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID('4', { message: 'Invalid organization ID format' })
+  organizationId?: string;
 }

--- a/src/modules/users/user.service.ts
+++ b/src/modules/users/user.service.ts
@@ -26,7 +26,7 @@ export class UserService {
   }
 
   async getUser({ userId }: { userId: string }) {
-    return this.prisma.user.findMany({
+    return this.prisma.user.findUnique({
       where: { id: userId },
       select: {
         id: true,
@@ -47,7 +47,7 @@ export class UserService {
     firstName: string;
     lastName: string;
     role?: UserRole;
-    organizationId: string;
+    organizationId?: string;
   }) {
     const password = await bcrypt.hash(data.password, 10);
     return this.prisma.user.create({
@@ -57,7 +57,9 @@ export class UserService {
         firstName: data.firstName,
         lastName: data.lastName,
         role: data.role ?? UserRole.OUVRIER,
-        organization: { connect: { id: data.organizationId } },
+        ...(data.organizationId && {
+          organization: { connect: { id: data.organizationId } },
+        }),
       },
     });
   }


### PR DESCRIPTION
Suppression de la contrainte obligatoire sur organizationId dans le schéma Prisma, le DTO et le service utilisateur Correction du flux d’inscription pour permettre la création d’un utilisateur sans organisation Ajout d’une route racine pour éviter la 404 sur /
Ajout de la validation globale des DTOs auth
Correction du comportement des endpoints protégés (403 si rôle insuffisant)