### PR TITLE
feat: push migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ lerna-debug.log*
 .temp
 .tmp
 .vscode
-migrations

--- a/prisma/migrations/20260305104938_make_organization_optional/migration.sql
+++ b/prisma/migrations/20260305104938_make_organization_optional/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "User" DROP CONSTRAINT "User_organizationId_fkey";
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "organizationId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -14,6 +14,7 @@ export class AuthService {
   ) {}
 
   async login(dto: LoginDto) {
+    console.log('[LOGIN] Tentative:', dto);
     const existingUser = await this.userService.findByEmail(dto.email);
 
     if (!existingUser) {
@@ -28,6 +29,7 @@ export class AuthService {
   }
 
   async register(dto: RegisterDto) {
+    console.log('[REGISTER] Tentative:', dto);
     const existingUser = await this.userService.findByEmail(dto.email);
 
     if (existingUser) {


### PR DESCRIPTION
This pull request introduces a database migration to make the `organizationId` field optional for users, and adds logging to authentication methods for better visibility during login and registration attempts.

**Database migration:**

* Made the `organizationId` field on the `User` table optional by dropping the NOT NULL constraint and updating the foreign key to set the field to `NULL` on delete. (`prisma/migrations/20260305104938_make_organization_optional/migration.sql`)

**Authentication logging:**

* Added console logs to the `login` and `register` methods in `AuthService` to print the DTOs being processed, aiding in debugging and monitoring authentication attempts. (`src/modules/auth/auth.service.ts`) [[1]](diffhunk://#diff-fdfdc5f661ae4e2563a2e95285b88812b78ee43f05fc95bb88ba319759981116R17) [[2]](diffhunk://#diff-fdfdc5f661ae4e2563a2e95285b88812b78ee43f05fc95bb88ba319759981116R32)