### PR TITLE
feat: set default role at ADMIN for all user

### DIFF
--- a/src/modules/users/user.service.ts
+++ b/src/modules/users/user.service.ts
@@ -56,7 +56,7 @@ export class UserService {
         password,
         firstName: data.firstName,
         lastName: data.lastName,
-        role: data.role ?? UserRole.OUVRIER,
+        role: data.role ?? UserRole.ADMIN,
         ...(data.organizationId && {
           organization: { connect: { id: data.organizationId } },
         }),


### PR DESCRIPTION
This pull request makes a small change to the default user role assignment logic in the `UserService`. The default role for new users is now set to `ADMIN` instead of `OUVRIER` if no role is provided during user creation.
<img width="1283" height="1134" alt="image" src="https://github.com/user-attachments/assets/136cbdd4-4316-4c1d-bef8-5660a93c74b2" />
