### PR TITLE
feat: add new champ id for summary dashboard

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -10,6 +10,7 @@ import { DashboardService } from './dashboard.service';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { UserRole } from '../../shared/types/roles.enum';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import {
   DashboardSummaryQueryDto,
   DashboardSummaryResponseDto,
@@ -34,7 +35,7 @@ export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('summary')
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiQuery({
     name: 'startDate',
@@ -65,7 +66,7 @@ export class DashboardController {
   }
 
   @Get('reports')
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiQuery({
     name: 'startDate',

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -40,11 +40,16 @@ export class DashboardService {
       }
       const usages = await this.prisma.resourceUsage.findMany(usageQuery);
 
-      const categories = ['Voiles', 'Planchers', 'Poutres', 'Superstructure'];
+      const categories = [
+        { id: 1, name: 'Voiles' },
+        { id: 2, name: 'Planchers' },
+        { id: 3, name: 'Poutres' },
+        { id: 4, name: 'Superstructure' },
+      ];
 
       const categoryKpis: CategoryKpiDto[] = categories.map((cat) => {
         const catResources = resources.filter((r) =>
-          r.name.toLowerCase().includes(cat.toLowerCase()),
+          r.name.toLowerCase().includes(cat.name.toLowerCase()),
         );
         const catUsages = usages.filter((u) =>
           catResources.some((r) => r.id === u.resourceId),
@@ -64,7 +69,7 @@ export class DashboardService {
               100,
           ),
         );
-        return { name: cat, progress, spent };
+        return { id: cat.id, name: cat.name, progress, spent };
       });
 
       const globalProgress = Math.round(

--- a/src/modules/dashboard/dto/dashboard-summary.dto.ts
+++ b/src/modules/dashboard/dto/dashboard-summary.dto.ts
@@ -32,6 +32,9 @@ export class DashboardSummaryQueryDto {
 
 export class CategoryKpiDto {
   @ApiProperty()
+  id: number;
+
+  @ApiProperty()
   name: string;
 
   @ApiProperty()

--- a/test/modules/dashboard/dashboard.e2e-spec.ts
+++ b/test/modules/dashboard/dashboard.e2e-spec.ts
@@ -5,6 +5,7 @@ import { App } from 'supertest/types';
 import { AppModule } from '../../../src/app.module';
 import { PrismaService } from '../../../src/lib/prisma/prisma.service';
 import { RolesGuard } from '../../../src/modules/auth/roles.guard';
+import { JwtAuthGuard } from '../../../src/modules/auth/jwt-auth.guard';
 
 describe('DashboardController (e2e)', () => {
   let app: INestApplication<App>;
@@ -27,6 +28,8 @@ describe('DashboardController (e2e)', () => {
         $connect: jest.fn(),
         $disconnect: jest.fn(),
       })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
       .overrideGuard(RolesGuard)
       .useValue({ canActivate: jest.fn(() => true) })
       .compile();


### PR DESCRIPTION
This pull request enhances the security of the dashboard endpoints by introducing JWT authentication and improves the structure of KPI category data. The main changes are grouped below:

**Authentication & Security Improvements:**

* Added `JwtAuthGuard` to the dashboard controller, ensuring that both the `summary` and `reports` endpoints require JWT authentication in addition to role-based access control. (`src/modules/dashboard/dashboard.controller.ts`) [[1]](diffhunk://#diff-b72e9bccd244f843cb1f73782556ee9cf142b26c6407bb6eac8431930c76cba3R13) [[2]](diffhunk://#diff-b72e9bccd244f843cb1f73782556ee9cf142b26c6407bb6eac8431930c76cba3L37-R38) [[3]](diffhunk://#diff-b72e9bccd244f843cb1f73782556ee9cf142b26c6407bb6eac8431930c76cba3L68-R69)
* Updated the e2e test setup to mock `JwtAuthGuard` alongside `RolesGuard`, ensuring tests reflect the new authentication requirements. (`test/modules/dashboard/dashboard.e2e-spec.ts`) [[1]](diffhunk://#diff-52ada9d3c4d2f699586a5e7af2db7bdde8d48d51b9bc1c461ba81c8e13a540bbR8) [[2]](diffhunk://#diff-52ada9d3c4d2f699586a5e7af2db7bdde8d48d51b9bc1c461ba81c8e13a540bbR31-R32)

**KPI Category Data Structure Improvements:**

* Changed the `categories` array in `DashboardService` from a list of strings to an array of objects with `id` and `name`, allowing for more robust category identification and future extensibility. (`src/modules/dashboard/dashboard.service.ts`)
* Updated the mapping logic and returned KPI data to include the new `id` field for each category. (`src/modules/dashboard/dashboard.service.ts`)
* Added the `id` property to the `CategoryKpiDto` class and decorated it for API documentation, ensuring the new field is exposed and documented in API responses. (`src/modules/dashboard/dto/dashboard-summary.dto.ts`)