### PR TITLE
feat: add --no-build option for launch backend without complete re-build

### DIFF
--- a/prisma/migrations/20260305135934_add_generic_table_models/migration.sql
+++ b/prisma/migrations/20260305135934_add_generic_table_models/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "GenericTable" (
+    "id" UUID NOT NULL,
+    "siteId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "columns" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GenericTable_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GenericTableRow" (
+    "id" UUID NOT NULL,
+    "tableId" UUID NOT NULL,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GenericTableRow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GenericTable_siteId_idx" ON "GenericTable"("siteId");
+
+-- CreateIndex
+CREATE INDEX "GenericTableRow_tableId_idx" ON "GenericTableRow"("tableId");
+
+-- AddForeignKey
+ALTER TABLE "GenericTable" ADD CONSTRAINT "GenericTable_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GenericTableRow" ADD CONSTRAINT "GenericTableRow_tableId_fkey" FOREIGN KEY ("tableId") REFERENCES "GenericTable"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,7 @@ model Site {
 	documents    Document[]
 	reports      Report[]
 	workforceDays WorkforceDay[]
+	genericTables GenericTable[]
 
 	@@index([organizationId])
 }
@@ -335,6 +336,32 @@ model WorkforceEntry {
 
 	@@index([workforceDayId])
 	@@index([workerId])
+}
+
+model GenericTable {
+	id        String   @id @default(uuid()) @db.Uuid
+	siteId    String   @db.Uuid
+	name      String
+	columns   Json
+	createdAt DateTime @default(now())
+	updatedAt DateTime @updatedAt
+
+	site Site              @relation(fields: [siteId], references: [id])
+	rows GenericTableRow[]
+
+	@@index([siteId])
+}
+
+model GenericTableRow {
+	id        String   @id @default(uuid()) @db.Uuid
+	tableId   String   @db.Uuid
+	data      Json
+	createdAt DateTime @default(now())
+	updatedAt DateTime @updatedAt
+
+	table GenericTable @relation(fields: [tableId], references: [id], onDelete: Cascade)
+
+	@@index([tableId])
 }
 
 model test {

--- a/run.sh
+++ b/run.sh
@@ -6,12 +6,21 @@ set -e
 
 if [ "$1" = "backend" ]; then
   echo "[Konstrukt BACKEND] Démarrage du backend et de la base Postgres via Docker Compose..."
-  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-    docker compose up -d --build
-  elif command -v docker-compose >/dev/null 2>&1; then
-    docker-compose up -d --build
+  if [ "$2" = "--no-build" ]; then
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      docker compose up -d
+    elif command -v docker-compose >/dev/null 2>&1; then
+      docker-compose up -d
+    fi
+    echo "[Konstrukt BACKEND] Les services sont lancés (sans rebuild)"
+  else
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      docker compose up -d --build
+    elif command -v docker-compose >/dev/null 2>&1; then
+      docker-compose up -d --build
+    fi
+    echo "[Konstrukt BACKEND] Les services sont lancés (avec rebuild)"
   fi
-  echo "[Konstrukt BACKEND] Les services sont lancés"
   echo "[Konstrukt BACKEND] Accès API : http://localhost:3000"
   echo "[Konstrukt BACKEND] Accès DB : postgresql://konstrukt:konstrukt@localhost:5432/konstrukt"
   echo "[Konstrukt BACKEND] Pour arrêter les services : ./run.sh stop"

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 import { PrismaModule } from '../../lib/prisma/prisma.module';
+import { GenericTableModule } from './generic-table.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, GenericTableModule],
   controllers: [DashboardController],
   providers: [DashboardService],
 })

--- a/src/modules/dashboard/dto/add-generic-table-row.dto.ts
+++ b/src/modules/dashboard/dto/add-generic-table-row.dto.ts
@@ -1,0 +1,6 @@
+import { IsObject } from 'class-validator';
+
+export class AddGenericTableRowDto {
+  @IsObject()
+  data: Record<string, any>;
+}

--- a/src/modules/dashboard/dto/create-generic-table-row.dto.ts
+++ b/src/modules/dashboard/dto/create-generic-table-row.dto.ts
@@ -1,0 +1,9 @@
+import { IsUUID, IsObject } from 'class-validator';
+
+export class CreateGenericTableRowDto {
+  @IsUUID()
+  tableId: string;
+
+  @IsObject()
+  data: Record<string, any>;
+}

--- a/src/modules/dashboard/dto/create-generic-table.dto.ts
+++ b/src/modules/dashboard/dto/create-generic-table.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsUUID, IsObject } from 'class-validator';
+
+export class CreateGenericTableDto {
+  @IsString()
+  name: string;
+
+  @IsObject()
+  columns: object;
+
+  @IsUUID()
+  siteId: string;
+}

--- a/src/modules/dashboard/dto/update-generic-table-row.dto.ts
+++ b/src/modules/dashboard/dto/update-generic-table-row.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateGenericTableRowDto } from './create-generic-table-row.dto';
+
+export class UpdateGenericTableRowDto extends PartialType(
+  CreateGenericTableRowDto,
+) {}

--- a/src/modules/dashboard/dto/update-generic-table-row.dto.ts
+++ b/src/modules/dashboard/dto/update-generic-table-row.dto.ts
@@ -1,6 +1,7 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateGenericTableRowDto } from './create-generic-table-row.dto';
+import { IsObject, IsOptional } from 'class-validator';
 
-export class UpdateGenericTableRowDto extends PartialType(
-  CreateGenericTableRowDto,
-) {}
+export class UpdateGenericTableRowDto {
+  @IsObject()
+  @IsOptional()
+  data?: Record<string, any>;
+}

--- a/src/modules/dashboard/dto/update-generic-table.dto.ts
+++ b/src/modules/dashboard/dto/update-generic-table.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateGenericTableDto } from './create-generic-table.dto';
+
+export class UpdateGenericTableDto extends PartialType(CreateGenericTableDto) {}

--- a/src/modules/dashboard/generic-table.controller.ts
+++ b/src/modules/dashboard/generic-table.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Body,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -14,19 +15,27 @@ import {
   ApiResponse,
   ApiParam,
   ApiQuery,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { GenericTableService } from './generic-table.service';
 import { CreateGenericTableDto } from './dto/create-generic-table.dto';
 import { UpdateGenericTableDto } from './dto/update-generic-table.dto';
-import { CreateGenericTableRowDto } from './dto/create-generic-table-row.dto';
+import { AddGenericTableRowDto } from './dto/add-generic-table-row.dto';
 import { UpdateGenericTableRowDto } from './dto/update-generic-table-row.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from '../../shared/types/roles.enum';
 
 @ApiTags('Dashboard - Generic Tables')
+@ApiBearerAuth()
 @Controller('dashboard/tables')
 export class GenericTableController {
   constructor(private readonly service: GenericTableService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Create a new generic table' })
   @ApiResponse({ status: 201, description: 'Table created successfully.' })
   @ApiResponse({ status: 400, description: 'Validation failed.' })
@@ -35,6 +44,8 @@ export class GenericTableController {
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Get a table by ID' })
   @ApiParam({ name: 'id', description: 'Table UUID' })
   @ApiResponse({ status: 200, description: 'Table found.' })
@@ -44,6 +55,8 @@ export class GenericTableController {
   }
 
   @Put(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Update a table' })
   @ApiParam({ name: 'id', description: 'Table UUID' })
   @ApiResponse({ status: 200, description: 'Table updated successfully.' })
@@ -54,6 +67,8 @@ export class GenericTableController {
   }
 
   @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Delete a table' })
   @ApiParam({ name: 'id', description: 'Table UUID' })
   @ApiResponse({ status: 200, description: 'Table deleted successfully.' })
@@ -63,6 +78,8 @@ export class GenericTableController {
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'List all tables' })
   @ApiQuery({
     name: 'siteId',
@@ -75,6 +92,8 @@ export class GenericTableController {
   }
 
   @Post(':tableId/rows')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Add a row to a table' })
   @ApiParam({ name: 'tableId', description: 'Table UUID' })
   @ApiResponse({ status: 201, description: 'Row added successfully.' })
@@ -82,12 +101,14 @@ export class GenericTableController {
   @ApiResponse({ status: 404, description: 'Table not found.' })
   addRow(
     @Param('tableId') tableId: string,
-    @Body() dto: CreateGenericTableRowDto,
+    @Body() dto: AddGenericTableRowDto,
   ) {
-    return this.service.addRow({ ...dto, tableId });
+    return this.service.addRow({ tableId, data: dto.data });
   }
 
   @Get(':tableId/rows')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'List all rows in a table' })
   @ApiParam({ name: 'tableId', description: 'Table UUID' })
   @ApiResponse({ status: 200, description: 'List of rows.' })
@@ -97,6 +118,8 @@ export class GenericTableController {
   }
 
   @Get('rows/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Get a row by ID' })
   @ApiParam({ name: 'id', description: 'Row UUID' })
   @ApiResponse({ status: 200, description: 'Row found.' })
@@ -106,6 +129,8 @@ export class GenericTableController {
   }
 
   @Put('rows/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Update a row' })
   @ApiParam({ name: 'id', description: 'Row UUID' })
   @ApiResponse({ status: 200, description: 'Row updated successfully.' })
@@ -116,6 +141,8 @@ export class GenericTableController {
   }
 
   @Delete('rows/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.CHEF_PROJET, UserRole.CONDUCTEUR_TRAVAUX)
   @ApiOperation({ summary: 'Delete a row' })
   @ApiParam({ name: 'id', description: 'Row UUID' })
   @ApiResponse({ status: 200, description: 'Row deleted successfully.' })

--- a/src/modules/dashboard/generic-table.controller.ts
+++ b/src/modules/dashboard/generic-table.controller.ts
@@ -1,0 +1,126 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { GenericTableService } from './generic-table.service';
+import { CreateGenericTableDto } from './dto/create-generic-table.dto';
+import { UpdateGenericTableDto } from './dto/update-generic-table.dto';
+import { CreateGenericTableRowDto } from './dto/create-generic-table-row.dto';
+import { UpdateGenericTableRowDto } from './dto/update-generic-table-row.dto';
+
+@ApiTags('Dashboard - Generic Tables')
+@Controller('dashboard/tables')
+export class GenericTableController {
+  constructor(private readonly service: GenericTableService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new generic table' })
+  @ApiResponse({ status: 201, description: 'Table created successfully.' })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  createTable(@Body() dto: CreateGenericTableDto) {
+    return this.service.createTable(dto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a table by ID' })
+  @ApiParam({ name: 'id', description: 'Table UUID' })
+  @ApiResponse({ status: 200, description: 'Table found.' })
+  @ApiResponse({ status: 404, description: 'Table not found.' })
+  getTable(@Param('id') id: string) {
+    return this.service.getTable(id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a table' })
+  @ApiParam({ name: 'id', description: 'Table UUID' })
+  @ApiResponse({ status: 200, description: 'Table updated successfully.' })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  @ApiResponse({ status: 404, description: 'Table not found.' })
+  updateTable(@Param('id') id: string, @Body() dto: UpdateGenericTableDto) {
+    return this.service.updateTable(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a table' })
+  @ApiParam({ name: 'id', description: 'Table UUID' })
+  @ApiResponse({ status: 200, description: 'Table deleted successfully.' })
+  @ApiResponse({ status: 404, description: 'Table not found.' })
+  deleteTable(@Param('id') id: string) {
+    return this.service.deleteTable(id);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all tables' })
+  @ApiQuery({
+    name: 'siteId',
+    required: false,
+    description: 'Filter by site UUID',
+  })
+  @ApiResponse({ status: 200, description: 'List of tables.' })
+  listTables(@Query('siteId') siteId?: string) {
+    return this.service.listTables(siteId);
+  }
+
+  @Post(':tableId/rows')
+  @ApiOperation({ summary: 'Add a row to a table' })
+  @ApiParam({ name: 'tableId', description: 'Table UUID' })
+  @ApiResponse({ status: 201, description: 'Row added successfully.' })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  @ApiResponse({ status: 404, description: 'Table not found.' })
+  addRow(
+    @Param('tableId') tableId: string,
+    @Body() dto: CreateGenericTableRowDto,
+  ) {
+    return this.service.addRow({ ...dto, tableId });
+  }
+
+  @Get(':tableId/rows')
+  @ApiOperation({ summary: 'List all rows in a table' })
+  @ApiParam({ name: 'tableId', description: 'Table UUID' })
+  @ApiResponse({ status: 200, description: 'List of rows.' })
+  @ApiResponse({ status: 404, description: 'Table not found.' })
+  listRows(@Param('tableId') tableId: string) {
+    return this.service.listRows(tableId);
+  }
+
+  @Get('rows/:id')
+  @ApiOperation({ summary: 'Get a row by ID' })
+  @ApiParam({ name: 'id', description: 'Row UUID' })
+  @ApiResponse({ status: 200, description: 'Row found.' })
+  @ApiResponse({ status: 404, description: 'Row not found.' })
+  getRow(@Param('id') id: string) {
+    return this.service.getRow(id);
+  }
+
+  @Put('rows/:id')
+  @ApiOperation({ summary: 'Update a row' })
+  @ApiParam({ name: 'id', description: 'Row UUID' })
+  @ApiResponse({ status: 200, description: 'Row updated successfully.' })
+  @ApiResponse({ status: 400, description: 'Validation failed.' })
+  @ApiResponse({ status: 404, description: 'Row not found.' })
+  updateRow(@Param('id') id: string, @Body() dto: UpdateGenericTableRowDto) {
+    return this.service.updateRow(id, dto);
+  }
+
+  @Delete('rows/:id')
+  @ApiOperation({ summary: 'Delete a row' })
+  @ApiParam({ name: 'id', description: 'Row UUID' })
+  @ApiResponse({ status: 200, description: 'Row deleted successfully.' })
+  @ApiResponse({ status: 404, description: 'Row not found.' })
+  deleteRow(@Param('id') id: string) {
+    return this.service.deleteRow(id);
+  }
+}

--- a/src/modules/dashboard/generic-table.module.ts
+++ b/src/modules/dashboard/generic-table.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../lib/prisma/prisma.module';
+import { GenericTableService } from './generic-table.service';
+import { GenericTableController } from './generic-table.controller';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [GenericTableController],
+  providers: [GenericTableService],
+  exports: [GenericTableService],
+})
+export class GenericTableModule {}

--- a/src/modules/dashboard/generic-table.service.ts
+++ b/src/modules/dashboard/generic-table.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../lib/prisma/prisma.service';
+import { CreateGenericTableDto } from './dto/create-generic-table.dto';
+import { UpdateGenericTableDto } from './dto/update-generic-table.dto';
+import { CreateGenericTableRowDto } from './dto/create-generic-table-row.dto';
+import { UpdateGenericTableRowDto } from './dto/update-generic-table-row.dto';
+
+@Injectable()
+export class GenericTableService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createTable(dto: CreateGenericTableDto) {
+    return await this.prisma.genericTable.create({ data: dto });
+  }
+
+  async getTable(id: string) {
+    return await this.prisma.genericTable.findUnique({
+      where: { id },
+      include: { rows: true },
+    });
+  }
+
+  async updateTable(id: string, dto: UpdateGenericTableDto) {
+    return await this.prisma.genericTable.update({ where: { id }, data: dto });
+  }
+
+  async deleteTable(id: string) {
+    return await this.prisma.genericTable.delete({ where: { id } });
+  }
+
+  async listTables(siteId?: string) {
+    return await this.prisma.genericTable.findMany({
+      where: siteId ? { siteId } : {},
+      include: { rows: true },
+    });
+  }
+
+  async addRow(dto: CreateGenericTableRowDto) {
+    return await this.prisma.genericTableRow.create({ data: dto });
+  }
+
+  async updateRow(id: string, dto: UpdateGenericTableRowDto) {
+    return await this.prisma.genericTableRow.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  async deleteRow(id: string) {
+    return await this.prisma.genericTableRow.delete({ where: { id } });
+  }
+
+  async getRow(id: string) {
+    return await this.prisma.genericTableRow.findUnique({ where: { id } });
+  }
+
+  async listRows(tableId: string) {
+    return await this.prisma.genericTableRow.findMany({ where: { tableId } });
+  }
+}

--- a/src/modules/dashboard/generic-table.service.ts
+++ b/src/modules/dashboard/generic-table.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../lib/prisma/prisma.service';
 import { CreateGenericTableDto } from './dto/create-generic-table.dto';
 import { UpdateGenericTableDto } from './dto/update-generic-table.dto';
 import { CreateGenericTableRowDto } from './dto/create-generic-table-row.dto';
 import { UpdateGenericTableRowDto } from './dto/update-generic-table-row.dto';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class GenericTableService {
@@ -14,18 +15,47 @@ export class GenericTableService {
   }
 
   async getTable(id: string) {
-    return await this.prisma.genericTable.findUnique({
+    const table = await this.prisma.genericTable.findUnique({
       where: { id },
       include: { rows: true },
     });
+
+    if (!table) {
+      throw new NotFoundException(`Table with ID ${id} not found`);
+    }
+
+    return table;
   }
 
   async updateTable(id: string, dto: UpdateGenericTableDto) {
-    return await this.prisma.genericTable.update({ where: { id }, data: dto });
+    try {
+      return await this.prisma.genericTable.update({
+        where: { id },
+        data: dto,
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new NotFoundException(`Table with ID ${id} not found`);
+      }
+      throw error;
+    }
   }
 
   async deleteTable(id: string) {
-    return await this.prisma.genericTable.delete({ where: { id } });
+    try {
+      return await this.prisma.genericTable.delete({ where: { id } });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new NotFoundException(`Table with ID ${id} not found`);
+      }
+      throw error;
+    }
   }
 
   async listTables(siteId?: string) {
@@ -36,25 +66,69 @@ export class GenericTableService {
   }
 
   async addRow(dto: CreateGenericTableRowDto) {
-    return await this.prisma.genericTableRow.create({ data: dto });
+    try {
+      return await this.prisma.genericTableRow.create({ data: dto });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2003'
+      ) {
+        throw new NotFoundException(`Table with ID ${dto.tableId} not found`);
+      }
+      throw error;
+    }
   }
 
   async updateRow(id: string, dto: UpdateGenericTableRowDto) {
-    return await this.prisma.genericTableRow.update({
-      where: { id },
-      data: dto,
-    });
+    try {
+      return await this.prisma.genericTableRow.update({
+        where: { id },
+        data: dto,
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new NotFoundException(`Row with ID ${id} not found`);
+      }
+      throw error;
+    }
   }
 
   async deleteRow(id: string) {
-    return await this.prisma.genericTableRow.delete({ where: { id } });
+    try {
+      return await this.prisma.genericTableRow.delete({ where: { id } });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new NotFoundException(`Row with ID ${id} not found`);
+      }
+      throw error;
+    }
   }
 
   async getRow(id: string) {
-    return await this.prisma.genericTableRow.findUnique({ where: { id } });
+    const row = await this.prisma.genericTableRow.findUnique({ where: { id } });
+
+    if (!row) {
+      throw new NotFoundException(`Row with ID ${id} not found`);
+    }
+
+    return row;
   }
 
   async listRows(tableId: string) {
+    const table = await this.prisma.genericTable.findUnique({
+      where: { id: tableId },
+    });
+
+    if (!table) {
+      throw new NotFoundException(`Table with ID ${tableId} not found`);
+    }
+
     return await this.prisma.genericTableRow.findMany({ where: { tableId } });
   }
 }

--- a/test/modules/dashboard/generic-table.controller.spec.ts
+++ b/test/modules/dashboard/generic-table.controller.spec.ts
@@ -1,0 +1,202 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenericTableController } from '../../../src/modules/dashboard/generic-table.controller';
+import { GenericTableService } from '../../../src/modules/dashboard/generic-table.service';
+import { CreateGenericTableDto } from '../../../src/modules/dashboard/dto/create-generic-table.dto';
+import { UpdateGenericTableDto } from '../../../src/modules/dashboard/dto/update-generic-table.dto';
+import { CreateGenericTableRowDto } from '../../../src/modules/dashboard/dto/create-generic-table-row.dto';
+import { UpdateGenericTableRowDto } from '../../../src/modules/dashboard/dto/update-generic-table-row.dto';
+
+describe('GenericTableController', () => {
+  let controller: GenericTableController;
+  let service: GenericTableService;
+
+  const mockTable = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Table',
+    columns: { col1: 'string', col2: 'number' },
+    siteId: '550e8400-e29b-41d4-a716-446655440001',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    rows: [],
+  };
+
+  const mockRow = {
+    id: '550e8400-e29b-41d4-a716-446655440002',
+    tableId: '550e8400-e29b-41d4-a716-446655440000',
+    data: { col1: 'value1', col2: 42 },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GenericTableController],
+      providers: [
+        {
+          provide: GenericTableService,
+          useValue: {
+            createTable: jest.fn().mockResolvedValue(mockTable),
+            getTable: jest.fn().mockResolvedValue(mockTable),
+            updateTable: jest.fn().mockResolvedValue(mockTable),
+            deleteTable: jest.fn().mockResolvedValue(mockTable),
+            listTables: jest.fn().mockResolvedValue([mockTable]),
+            addRow: jest.fn().mockResolvedValue(mockRow),
+            listRows: jest.fn().mockResolvedValue([mockRow]),
+            getRow: jest.fn().mockResolvedValue(mockRow),
+            updateRow: jest.fn().mockResolvedValue(mockRow),
+            deleteRow: jest.fn().mockResolvedValue(mockRow),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<GenericTableController>(GenericTableController);
+    service = module.get<GenericTableService>(GenericTableService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createTable', () => {
+    it('should create a new table', async () => {
+      const dto: CreateGenericTableDto = {
+        name: 'Test Table',
+        columns: { col1: 'string', col2: 'number' },
+        siteId: '550e8400-e29b-41d4-a716-446655440001',
+      };
+
+      const result = await controller.createTable(dto);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.createTable).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('getTable', () => {
+    it('should return a table by ID', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await controller.getTable(tableId);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.getTable).toHaveBeenCalledWith(tableId);
+    });
+  });
+
+  describe('updateTable', () => {
+    it('should update a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+      const dto: UpdateGenericTableDto = {
+        name: 'Updated Table',
+      };
+
+      const result = await controller.updateTable(tableId, dto);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.updateTable).toHaveBeenCalledWith(tableId, dto);
+    });
+  });
+
+  describe('deleteTable', () => {
+    it('should delete a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await controller.deleteTable(tableId);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.deleteTable).toHaveBeenCalledWith(tableId);
+    });
+  });
+
+  describe('listTables', () => {
+    it('should list all tables without filter', async () => {
+      const result = await controller.listTables();
+
+      expect(result).toEqual([mockTable]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.listTables).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should list tables filtered by siteId', async () => {
+      const siteId = '550e8400-e29b-41d4-a716-446655440001';
+
+      const result = await controller.listTables(siteId);
+
+      expect(result).toEqual([mockTable]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.listTables).toHaveBeenCalledWith(siteId);
+    });
+  });
+
+  describe('addRow', () => {
+    it('should add a row to a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+      const dto: CreateGenericTableRowDto = {
+        tableId,
+        data: { col1: 'value1', col2: 42 },
+      };
+
+      const result = await controller.addRow(tableId, dto);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.addRow).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('listRows', () => {
+    it('should list all rows in a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await controller.listRows(tableId);
+
+      expect(result).toEqual([mockRow]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.listRows).toHaveBeenCalledWith(tableId);
+    });
+  });
+
+  describe('getRow', () => {
+    it('should return a row by ID', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+
+      const result = await controller.getRow(rowId);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.getRow).toHaveBeenCalledWith(rowId);
+    });
+  });
+
+  describe('updateRow', () => {
+    it('should update a row', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+      const dto: UpdateGenericTableRowDto = {
+        data: { col1: 'updated', col2: 100 },
+      };
+
+      const result = await controller.updateRow(rowId, dto);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.updateRow).toHaveBeenCalledWith(rowId, dto);
+    });
+  });
+
+  describe('deleteRow', () => {
+    it('should delete a row', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+
+      const result = await controller.deleteRow(rowId);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(service.deleteRow).toHaveBeenCalledWith(rowId);
+    });
+  });
+});

--- a/test/modules/dashboard/generic-table.controller.spec.ts
+++ b/test/modules/dashboard/generic-table.controller.spec.ts
@@ -3,7 +3,7 @@ import { GenericTableController } from '../../../src/modules/dashboard/generic-t
 import { GenericTableService } from '../../../src/modules/dashboard/generic-table.service';
 import { CreateGenericTableDto } from '../../../src/modules/dashboard/dto/create-generic-table.dto';
 import { UpdateGenericTableDto } from '../../../src/modules/dashboard/dto/update-generic-table.dto';
-import { CreateGenericTableRowDto } from '../../../src/modules/dashboard/dto/create-generic-table-row.dto';
+import { AddGenericTableRowDto } from '../../../src/modules/dashboard/dto/add-generic-table-row.dto';
 import { UpdateGenericTableRowDto } from '../../../src/modules/dashboard/dto/update-generic-table-row.dto';
 
 describe('GenericTableController', () => {
@@ -136,8 +136,7 @@ describe('GenericTableController', () => {
   describe('addRow', () => {
     it('should add a row to a table', async () => {
       const tableId = '550e8400-e29b-41d4-a716-446655440000';
-      const dto: CreateGenericTableRowDto = {
-        tableId,
+      const dto: AddGenericTableRowDto = {
         data: { col1: 'value1', col2: 42 },
       };
 
@@ -145,7 +144,7 @@ describe('GenericTableController', () => {
 
       expect(result).toEqual(mockRow);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(service.addRow).toHaveBeenCalledWith(dto);
+      expect(service.addRow).toHaveBeenCalledWith({ tableId, data: dto.data });
     });
   });
 

--- a/test/modules/dashboard/generic-table.e2e-spec.ts
+++ b/test/modules/dashboard/generic-table.e2e-spec.ts
@@ -63,7 +63,7 @@ describe('GenericTableController (e2e)', () => {
       .compile();
 
     app = moduleFixture.createNestApplication();
-    
+
     app.useGlobalPipes(
       new ValidationPipe({
         whitelist: true,
@@ -71,7 +71,7 @@ describe('GenericTableController (e2e)', () => {
         transform: true,
       }),
     );
-    
+
     prisma = moduleFixture.get<PrismaService>(PrismaService);
     await app.init();
   });
@@ -254,7 +254,6 @@ describe('GenericTableController (e2e)', () => {
         .post(`/dashboard/tables/${mockTableId}/rows`)
         .set('Authorization', 'Bearer test-token')
         .send({
-          tableId: mockTableId,
           data: { name: 'Test Item', quantity: 10, price: 99.99 },
         })
         .expect(201);
@@ -360,6 +359,17 @@ describe('GenericTableController (e2e)', () => {
         data: { data: { name: 'Updated Item', quantity: 20, price: 199.99 } },
       });
     });
+
+    it('should return 400 when trying to update tableId', async () => {
+      await request(app.getHttpServer())
+        .put(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          tableId: '550e8400-e29b-41d4-a716-446655440099',
+          data: { name: 'Updated Item' },
+        })
+        .expect(400);
+    });
   });
 
   describe('/dashboard/tables/rows/:id (DELETE)', () => {
@@ -394,7 +404,6 @@ describe('GenericTableController (e2e)', () => {
         .post(`/dashboard/tables/${mockTableId}/rows`)
         .set('Authorization', 'Bearer test-token')
         .send({
-          tableId: mockTableId,
           data: { name: 'Item', value: 100 },
         })
         .expect(201);

--- a/test/modules/dashboard/generic-table.e2e-spec.ts
+++ b/test/modules/dashboard/generic-table.e2e-spec.ts
@@ -1,0 +1,430 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../../../src/app.module';
+import { PrismaService } from '../../../src/lib/prisma/prisma.service';
+import { RolesGuard } from '../../../src/modules/auth/roles.guard';
+import { JwtAuthGuard } from '../../../src/modules/auth/jwt-auth.guard';
+
+describe('GenericTableController (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+
+  const mockSiteId = '550e8400-e29b-41d4-a716-446655440001';
+  const mockTableId = '550e8400-e29b-41d4-a716-446655440000';
+  const mockRowId = '550e8400-e29b-41d4-a716-446655440002';
+
+  const mockTable = {
+    id: mockTableId,
+    name: 'E2E Test Table',
+    columns: { name: 'string', quantity: 'number', price: 'number' },
+    siteId: mockSiteId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    rows: [],
+  };
+
+  const mockRow = {
+    id: mockRowId,
+    tableId: mockTableId,
+    data: { name: 'Test Item', quantity: 10, price: 99.99 },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        genericTable: {
+          create: jest.fn().mockResolvedValue(mockTable),
+          findUnique: jest.fn().mockResolvedValue(mockTable),
+          findMany: jest.fn().mockResolvedValue([mockTable]),
+          update: jest.fn().mockResolvedValue(mockTable),
+          delete: jest.fn().mockResolvedValue(mockTable),
+        },
+        genericTableRow: {
+          create: jest.fn().mockResolvedValue(mockRow),
+          findUnique: jest.fn().mockResolvedValue(mockRow),
+          findMany: jest.fn().mockResolvedValue([mockRow]),
+          update: jest.fn().mockResolvedValue(mockRow),
+          delete: jest.fn().mockResolvedValue(mockRow),
+        },
+        $connect: jest.fn(),
+        $disconnect: jest.fn(),
+      })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('/dashboard/tables (POST)', () => {
+    it('should create a new table', async () => {
+      interface CreateTableResponse {
+        id: string;
+        name: string;
+        columns: object;
+        siteId: string;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .post('/dashboard/tables')
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          name: 'E2E Test Table',
+          columns: { name: 'string', quantity: 'number', price: 'number' },
+          siteId: mockSiteId,
+        })
+        .expect(201);
+
+      const responseBody = response.body as CreateTableResponse;
+      expect(responseBody).toHaveProperty('id');
+      expect(responseBody).toHaveProperty('name', 'E2E Test Table');
+      expect(responseBody).toHaveProperty('columns');
+      expect(responseBody).toHaveProperty('siteId', mockSiteId);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.create).toHaveBeenCalled();
+    });
+
+    it('should return 400 for invalid data', async () => {
+      await request(app.getHttpServer())
+        .post('/dashboard/tables')
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          name: 'Test Table',
+          // Missing columns and siteId
+        })
+        .expect(400);
+    });
+  });
+
+  describe('/dashboard/tables (GET)', () => {
+    it('should list all tables', async () => {
+      interface Table {
+        id: string;
+        name: string;
+        columns: object;
+        siteId: string;
+        createdAt: string;
+        updatedAt: string;
+        rows: any[];
+      }
+
+      const response = await request(app.getHttpServer())
+        .get('/dashboard/tables')
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      const responseBody = response.body as Table[];
+      expect(Array.isArray(responseBody)).toBe(true);
+      if (responseBody.length > 0) {
+        const table = responseBody[0];
+        expect(table).toHaveProperty('id');
+        expect(table).toHaveProperty('name');
+        expect(table).toHaveProperty('columns');
+        expect(table).toHaveProperty('siteId');
+        expect(table).toHaveProperty('rows');
+      }
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalled();
+    });
+
+    it('should filter tables by siteId', async () => {
+      await request(app.getHttpServer())
+        .get(`/dashboard/tables?siteId=${mockSiteId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalledWith({
+        where: { siteId: mockSiteId },
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/:id (GET)', () => {
+    it('should get a table by ID', async () => {
+      interface TableWithRows {
+        id: string;
+        name: string;
+        columns: object;
+        siteId: string;
+        createdAt: string;
+        updatedAt: string;
+        rows: any[];
+      }
+
+      const response = await request(app.getHttpServer())
+        .get(`/dashboard/tables/${mockTableId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      const responseBody = response.body as TableWithRows;
+      expect(responseBody).toHaveProperty('id', mockTableId);
+      expect(responseBody).toHaveProperty('name');
+      expect(responseBody).toHaveProperty('columns');
+      expect(responseBody).toHaveProperty('rows');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findUnique).toHaveBeenCalledWith({
+        where: { id: mockTableId },
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/:id (PUT)', () => {
+    it('should update a table', async () => {
+      interface UpdatedTable {
+        id: string;
+        name: string;
+        columns: object;
+        siteId: string;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .put(`/dashboard/tables/${mockTableId}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          name: 'Updated Table Name',
+        })
+        .expect(200);
+
+      const responseBody = response.body as UpdatedTable;
+      expect(responseBody).toHaveProperty('id', mockTableId);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.update).toHaveBeenCalledWith({
+        where: { id: mockTableId },
+        data: { name: 'Updated Table Name' },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/:id (DELETE)', () => {
+    it('should delete a table', async () => {
+      await request(app.getHttpServer())
+        .delete(`/dashboard/tables/${mockTableId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.delete).toHaveBeenCalledWith({
+        where: { id: mockTableId },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/:tableId/rows (POST)', () => {
+    it('should add a row to a table', async () => {
+      interface CreatedRow {
+        id: string;
+        tableId: string;
+        data: Record<string, any>;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .post(`/dashboard/tables/${mockTableId}/rows`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          tableId: mockTableId,
+          data: { name: 'Test Item', quantity: 10, price: 99.99 },
+        })
+        .expect(201);
+
+      const responseBody = response.body as CreatedRow;
+      expect(responseBody).toHaveProperty('id');
+      expect(responseBody).toHaveProperty('tableId', mockTableId);
+      expect(responseBody).toHaveProperty('data');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.create).toHaveBeenCalled();
+    });
+
+    it('should return 400 for invalid row data', async () => {
+      await request(app.getHttpServer())
+        .post(`/dashboard/tables/${mockTableId}/rows`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          // Missing tableId and data
+        })
+        .expect(400);
+    });
+  });
+
+  describe('/dashboard/tables/:tableId/rows (GET)', () => {
+    it('should list all rows in a table', async () => {
+      interface Row {
+        id: string;
+        tableId: string;
+        data: Record<string, any>;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .get(`/dashboard/tables/${mockTableId}/rows`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      const responseBody = response.body as Row[];
+      expect(Array.isArray(responseBody)).toBe(true);
+      if (responseBody.length > 0) {
+        const row = responseBody[0];
+        expect(row).toHaveProperty('id');
+        expect(row).toHaveProperty('tableId');
+        expect(row).toHaveProperty('data');
+      }
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.findMany).toHaveBeenCalledWith({
+        where: { tableId: mockTableId },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/rows/:id (GET)', () => {
+    it('should get a row by ID', async () => {
+      interface Row {
+        id: string;
+        tableId: string;
+        data: Record<string, any>;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .get(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      const responseBody = response.body as Row;
+      expect(responseBody).toHaveProperty('id', mockRowId);
+      expect(responseBody).toHaveProperty('tableId');
+      expect(responseBody).toHaveProperty('data');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.findUnique).toHaveBeenCalledWith({
+        where: { id: mockRowId },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/rows/:id (PUT)', () => {
+    it('should update a row', async () => {
+      interface UpdatedRow {
+        id: string;
+        tableId: string;
+        data: Record<string, any>;
+        createdAt: string;
+        updatedAt: string;
+      }
+
+      const response = await request(app.getHttpServer())
+        .put(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          data: { name: 'Updated Item', quantity: 20, price: 199.99 },
+        })
+        .expect(200);
+
+      const responseBody = response.body as UpdatedRow;
+      expect(responseBody).toHaveProperty('id', mockRowId);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.update).toHaveBeenCalledWith({
+        where: { id: mockRowId },
+        data: { data: { name: 'Updated Item', quantity: 20, price: 199.99 } },
+      });
+    });
+  });
+
+  describe('/dashboard/tables/rows/:id (DELETE)', () => {
+    it('should delete a row', async () => {
+      await request(app.getHttpServer())
+        .delete(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.delete).toHaveBeenCalledWith({
+        where: { id: mockRowId },
+      });
+    });
+  });
+
+  describe('Complete workflow', () => {
+    it('should create table, add rows, update, and delete', async () => {
+      // Create table
+      await request(app.getHttpServer())
+        .post('/dashboard/tables')
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          name: 'Workflow Test Table',
+          columns: { name: 'string', value: 'number' },
+          siteId: mockSiteId,
+        })
+        .expect(201);
+
+      // Add row
+      await request(app.getHttpServer())
+        .post(`/dashboard/tables/${mockTableId}/rows`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          tableId: mockTableId,
+          data: { name: 'Item', value: 100 },
+        })
+        .expect(201);
+
+      // List rows
+      await request(app.getHttpServer())
+        .get(`/dashboard/tables/${mockTableId}/rows`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      // Update row
+      await request(app.getHttpServer())
+        .put(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          data: { name: 'Updated Item', value: 200 },
+        })
+        .expect(200);
+
+      // Delete row
+      await request(app.getHttpServer())
+        .delete(`/dashboard/tables/rows/${mockRowId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      // Delete table
+      await request(app.getHttpServer())
+        .delete(`/dashboard/tables/${mockTableId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+    });
+  });
+});

--- a/test/modules/dashboard/generic-table.integration-spec.ts
+++ b/test/modules/dashboard/generic-table.integration-spec.ts
@@ -1,0 +1,313 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenericTableService } from '../../../src/modules/dashboard/generic-table.service';
+import { PrismaService } from '../../../src/lib/prisma/prisma.service';
+import { CreateGenericTableDto } from '../../../src/modules/dashboard/dto/create-generic-table.dto';
+import { CreateGenericTableRowDto } from '../../../src/modules/dashboard/dto/create-generic-table-row.dto';
+
+describe('GenericTableService Integration', () => {
+  let service: GenericTableService;
+  let prisma: PrismaService;
+
+  const mockSiteId = '550e8400-e29b-41d4-a716-446655440001';
+
+  beforeAll(async () => {
+    const mockPrismaService = {
+      genericTable: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      genericTableRow: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenericTableService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<GenericTableService>(GenericTableService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  describe('Complete workflow: create table and manage rows', () => {
+    it('should create a table, add rows, and retrieve them', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+      const rowId1 = '550e8400-e29b-41d4-a716-446655440002';
+      const rowId2 = '550e8400-e29b-41d4-a716-446655440003';
+
+      const tableDto: CreateGenericTableDto = {
+        name: 'Integration Test Table',
+        columns: { name: 'string', quantity: 'number', price: 'number' },
+        siteId: mockSiteId,
+      };
+
+      const mockTable = {
+        id: tableId,
+        ...tableDto,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        rows: [],
+      };
+
+      (prisma.genericTable.create as jest.Mock).mockResolvedValue(mockTable);
+
+      const createdTable = await service.createTable(tableDto);
+      expect(createdTable).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.create).toHaveBeenCalledWith({
+        data: tableDto,
+      });
+
+      const row1Dto: CreateGenericTableRowDto = {
+        tableId,
+        data: { name: 'Item 1', quantity: 10, price: 99.99 },
+      };
+
+      const mockRow1 = {
+        id: rowId1,
+        ...row1Dto,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTableRow.create as jest.Mock).mockResolvedValue(mockRow1);
+
+      const row1 = await service.addRow(row1Dto);
+      expect(row1).toEqual(mockRow1);
+
+      const row2Dto: CreateGenericTableRowDto = {
+        tableId,
+        data: { name: 'Item 2', quantity: 5, price: 149.99 },
+      };
+
+      const mockRow2 = {
+        id: rowId2,
+        ...row2Dto,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTableRow.create as jest.Mock).mockResolvedValue(mockRow2);
+
+      const row2 = await service.addRow(row2Dto);
+      expect(row2).toEqual(mockRow2);
+
+      (prisma.genericTableRow.findMany as jest.Mock).mockResolvedValue([
+        mockRow1,
+        mockRow2,
+      ]);
+
+      const allRows = await service.listRows(tableId);
+      expect(allRows).toHaveLength(2);
+      expect(allRows).toEqual(expect.arrayContaining([mockRow1, mockRow2]));
+
+      const mockTableWithRows = {
+        ...mockTable,
+        rows: [mockRow1, mockRow2],
+      };
+
+      (prisma.genericTable.findUnique as jest.Mock).mockResolvedValue(
+        mockTableWithRows,
+      );
+
+      const tableWithRows = await service.getTable(tableId);
+      expect(tableWithRows.rows).toHaveLength(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findUnique).toHaveBeenCalledWith({
+        where: { id: tableId },
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('Filtering tables by site', () => {
+    it('should filter tables by siteId', async () => {
+      const siteId = mockSiteId;
+
+      const tablesForSite = [
+        {
+          id: '1',
+          name: 'Table 1',
+          columns: {},
+          siteId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          rows: [],
+        },
+        {
+          id: '2',
+          name: 'Table 2',
+          columns: {},
+          siteId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          rows: [],
+        },
+      ];
+
+      (prisma.genericTable.findMany as jest.Mock).mockResolvedValue(
+        tablesForSite,
+      );
+
+      const result = await service.listTables(siteId);
+
+      expect(result).toHaveLength(2);
+      expect(result.every((table) => table.siteId === siteId)).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalledWith({
+        where: { siteId },
+        include: { rows: true },
+      });
+    });
+
+    it('should return all tables when no siteId is provided', async () => {
+      const allTables = [
+        {
+          id: '1',
+          name: 'Table 1',
+          columns: {},
+          siteId: mockSiteId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          rows: [],
+        },
+        {
+          id: '2',
+          name: 'Table 2',
+          columns: {},
+          siteId: '550e8400-e29b-41d4-a716-446655440099',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          rows: [],
+        },
+      ];
+
+      (prisma.genericTable.findMany as jest.Mock).mockResolvedValue(allTables);
+
+      const result = await service.listTables();
+
+      expect(result).toHaveLength(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalledWith({
+        where: {},
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('Update operations', () => {
+    it('should update table name and columns', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+      const updateDto = {
+        name: 'Updated Table Name',
+        columns: { newCol: 'boolean' },
+      };
+
+      const updatedTable = {
+        id: tableId,
+        ...updateDto,
+        siteId: mockSiteId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTable.update as jest.Mock).mockResolvedValue(updatedTable);
+
+      const result = await service.updateTable(tableId, updateDto);
+
+      expect(result.name).toBe('Updated Table Name');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.update).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: updateDto,
+      });
+    });
+
+    it('should update row data', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+      const updateDto = {
+        data: { name: 'Updated Item', quantity: 20, price: 199.99 },
+      };
+
+      const updatedRow = {
+        id: rowId,
+        tableId: '550e8400-e29b-41d4-a716-446655440000',
+        ...updateDto,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTableRow.update as jest.Mock).mockResolvedValue(
+        updatedRow,
+      );
+
+      const result = await service.updateRow(rowId, updateDto);
+
+      expect(result.data).toEqual(updateDto.data);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.update).toHaveBeenCalledWith({
+        where: { id: rowId },
+        data: updateDto,
+      });
+    });
+  });
+
+  describe('Delete operations', () => {
+    it('should delete a row', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+
+      const deletedRow = {
+        id: rowId,
+        tableId: '550e8400-e29b-41d4-a716-446655440000',
+        data: { name: 'Item 1', quantity: 10, price: 99.99 },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTableRow.delete as jest.Mock).mockResolvedValue(
+        deletedRow,
+      );
+
+      const result = await service.deleteRow(rowId);
+
+      expect(result.id).toBe(rowId);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.delete).toHaveBeenCalledWith({
+        where: { id: rowId },
+      });
+    });
+
+    it('should delete a table and cascade delete its rows', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const deletedTable = {
+        id: tableId,
+        name: 'Table to Delete',
+        columns: {},
+        siteId: mockSiteId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      (prisma.genericTable.delete as jest.Mock).mockResolvedValue(deletedTable);
+
+      const result = await service.deleteTable(tableId);
+
+      expect(result.id).toBe(tableId);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.delete).toHaveBeenCalledWith({
+        where: { id: tableId },
+      });
+    });
+  });
+});

--- a/test/modules/dashboard/generic-table.service.spec.ts
+++ b/test/modules/dashboard/generic-table.service.spec.ts
@@ -1,0 +1,230 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenericTableService } from '../../../src/modules/dashboard/generic-table.service';
+import { PrismaService } from '../../../src/lib/prisma/prisma.service';
+import { CreateGenericTableDto } from '../../../src/modules/dashboard/dto/create-generic-table.dto';
+import { UpdateGenericTableDto } from '../../../src/modules/dashboard/dto/update-generic-table.dto';
+import { CreateGenericTableRowDto } from '../../../src/modules/dashboard/dto/create-generic-table-row.dto';
+import { UpdateGenericTableRowDto } from '../../../src/modules/dashboard/dto/update-generic-table-row.dto';
+
+describe('GenericTableService', () => {
+  let service: GenericTableService;
+  let prisma: PrismaService;
+
+  const mockTable = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Table',
+    columns: { col1: 'string', col2: 'number' },
+    siteId: '550e8400-e29b-41d4-a716-446655440001',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    rows: [],
+  };
+
+  const mockRow = {
+    id: '550e8400-e29b-41d4-a716-446655440002',
+    tableId: '550e8400-e29b-41d4-a716-446655440000',
+    data: { col1: 'value1', col2: 42 },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenericTableService,
+        {
+          provide: PrismaService,
+          useValue: {
+            genericTable: {
+              create: jest.fn().mockResolvedValue(mockTable),
+              findUnique: jest.fn().mockResolvedValue(mockTable),
+              findMany: jest.fn().mockResolvedValue([mockTable]),
+              update: jest.fn().mockResolvedValue(mockTable),
+              delete: jest.fn().mockResolvedValue(mockTable),
+            },
+            genericTableRow: {
+              create: jest.fn().mockResolvedValue(mockRow),
+              findUnique: jest.fn().mockResolvedValue(mockRow),
+              findMany: jest.fn().mockResolvedValue([mockRow]),
+              update: jest.fn().mockResolvedValue(mockRow),
+              delete: jest.fn().mockResolvedValue(mockRow),
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<GenericTableService>(GenericTableService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createTable', () => {
+    it('should create a new table', async () => {
+      const dto: CreateGenericTableDto = {
+        name: 'Test Table',
+        columns: { col1: 'string', col2: 'number' },
+        siteId: '550e8400-e29b-41d4-a716-446655440001',
+      };
+
+      const result = await service.createTable(dto);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.create).toHaveBeenCalledWith({ data: dto });
+    });
+  });
+
+  describe('getTable', () => {
+    it('should return a table with rows', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await service.getTable(tableId);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findUnique).toHaveBeenCalledWith({
+        where: { id: tableId },
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('updateTable', () => {
+    it('should update a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+      const dto: UpdateGenericTableDto = {
+        name: 'Updated Table',
+      };
+
+      const result = await service.updateTable(tableId, dto);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.update).toHaveBeenCalledWith({
+        where: { id: tableId },
+        data: dto,
+      });
+    });
+  });
+
+  describe('deleteTable', () => {
+    it('should delete a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await service.deleteTable(tableId);
+
+      expect(result).toEqual(mockTable);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.delete).toHaveBeenCalledWith({
+        where: { id: tableId },
+      });
+    });
+  });
+
+  describe('listTables', () => {
+    it('should list all tables without filter', async () => {
+      const result = await service.listTables();
+
+      expect(result).toEqual([mockTable]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalledWith({
+        where: {},
+        include: { rows: true },
+      });
+    });
+
+    it('should list tables filtered by siteId', async () => {
+      const siteId = '550e8400-e29b-41d4-a716-446655440001';
+
+      const result = await service.listTables(siteId);
+
+      expect(result).toEqual([mockTable]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTable.findMany).toHaveBeenCalledWith({
+        where: { siteId },
+        include: { rows: true },
+      });
+    });
+  });
+
+  describe('addRow', () => {
+    it('should add a row to a table', async () => {
+      const dto: CreateGenericTableRowDto = {
+        tableId: '550e8400-e29b-41d4-a716-446655440000',
+        data: { col1: 'value1', col2: 42 },
+      };
+
+      const result = await service.addRow(dto);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.create).toHaveBeenCalledWith({
+        data: dto,
+      });
+    });
+  });
+
+  describe('updateRow', () => {
+    it('should update a row', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+      const dto: UpdateGenericTableRowDto = {
+        data: { col1: 'updated', col2: 100 },
+      };
+
+      const result = await service.updateRow(rowId, dto);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.update).toHaveBeenCalledWith({
+        where: { id: rowId },
+        data: dto,
+      });
+    });
+  });
+
+  describe('deleteRow', () => {
+    it('should delete a row', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+
+      const result = await service.deleteRow(rowId);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.delete).toHaveBeenCalledWith({
+        where: { id: rowId },
+      });
+    });
+  });
+
+  describe('getRow', () => {
+    it('should return a row by ID', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440002';
+
+      const result = await service.getRow(rowId);
+
+      expect(result).toEqual(mockRow);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.findUnique).toHaveBeenCalledWith({
+        where: { id: rowId },
+      });
+    });
+  });
+
+  describe('listRows', () => {
+    it('should list all rows in a table', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const result = await service.listRows(tableId);
+
+      expect(result).toEqual([mockRow]);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(prisma.genericTableRow.findMany).toHaveBeenCalledWith({
+        where: { tableId },
+      });
+    });
+  });
+});

--- a/test/modules/dashboard/generic-table.service.spec.ts
+++ b/test/modules/dashboard/generic-table.service.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { GenericTableService } from '../../../src/modules/dashboard/generic-table.service';
 import { PrismaService } from '../../../src/lib/prisma/prisma.service';
 import { CreateGenericTableDto } from '../../../src/modules/dashboard/dto/create-generic-table.dto';
 import { UpdateGenericTableDto } from '../../../src/modules/dashboard/dto/update-generic-table.dto';
 import { CreateGenericTableRowDto } from '../../../src/modules/dashboard/dto/create-generic-table-row.dto';
 import { UpdateGenericTableRowDto } from '../../../src/modules/dashboard/dto/update-generic-table-row.dto';
+import { Prisma } from '@prisma/client';
 
 describe('GenericTableService', () => {
   let service: GenericTableService;
@@ -91,6 +93,15 @@ describe('GenericTableService', () => {
         include: { rows: true },
       });
     });
+
+    it('should throw NotFoundException when table not found', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440099';
+      jest.spyOn(prisma.genericTable, 'findUnique').mockResolvedValueOnce(null);
+
+      await expect(service.getTable(tableId)).rejects.toThrow(
+        new NotFoundException(`Table with ID ${tableId} not found`),
+      );
+    });
   });
 
   describe('updateTable', () => {
@@ -109,6 +120,23 @@ describe('GenericTableService', () => {
         data: dto,
       });
     });
+
+    it('should throw NotFoundException when table not found', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440099';
+      const dto: UpdateGenericTableDto = { name: 'Updated' };
+      const error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        },
+      );
+      jest.spyOn(prisma.genericTable, 'update').mockRejectedValueOnce(error);
+
+      await expect(service.updateTable(tableId, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
   describe('deleteTable', () => {
@@ -122,6 +150,22 @@ describe('GenericTableService', () => {
       expect(prisma.genericTable.delete).toHaveBeenCalledWith({
         where: { id: tableId },
       });
+    });
+
+    it('should throw NotFoundException when table not found', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440099';
+      const error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        },
+      );
+      jest.spyOn(prisma.genericTable, 'delete').mockRejectedValueOnce(error);
+
+      await expect(service.deleteTable(tableId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -166,6 +210,23 @@ describe('GenericTableService', () => {
         data: dto,
       });
     });
+
+    it('should throw NotFoundException when table not found', async () => {
+      const dto: CreateGenericTableRowDto = {
+        tableId: '550e8400-e29b-41d4-a716-446655440099',
+        data: { col1: 'value1' },
+      };
+      const error = new Prisma.PrismaClientKnownRequestError(
+        'Foreign key constraint failed',
+        {
+          code: 'P2003',
+          clientVersion: '5.0.0',
+        },
+      );
+      jest.spyOn(prisma.genericTableRow, 'create').mockRejectedValueOnce(error);
+
+      await expect(service.addRow(dto)).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('updateRow', () => {
@@ -184,6 +245,23 @@ describe('GenericTableService', () => {
         data: dto,
       });
     });
+
+    it('should throw NotFoundException when row not found', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440099';
+      const dto: UpdateGenericTableRowDto = { data: { col1: 'updated' } };
+      const error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        },
+      );
+      jest.spyOn(prisma.genericTableRow, 'update').mockRejectedValueOnce(error);
+
+      await expect(service.updateRow(rowId, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
   describe('deleteRow', () => {
@@ -197,6 +275,20 @@ describe('GenericTableService', () => {
       expect(prisma.genericTableRow.delete).toHaveBeenCalledWith({
         where: { id: rowId },
       });
+    });
+
+    it('should throw NotFoundException when row not found', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440099';
+      const error = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        },
+      );
+      jest.spyOn(prisma.genericTableRow, 'delete').mockRejectedValueOnce(error);
+
+      await expect(service.deleteRow(rowId)).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -212,6 +304,15 @@ describe('GenericTableService', () => {
         where: { id: rowId },
       });
     });
+
+    it('should throw NotFoundException when row not found', async () => {
+      const rowId = '550e8400-e29b-41d4-a716-446655440099';
+      jest
+        .spyOn(prisma.genericTableRow, 'findUnique')
+        .mockResolvedValueOnce(null);
+
+      await expect(service.getRow(rowId)).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('listRows', () => {
@@ -225,6 +326,15 @@ describe('GenericTableService', () => {
       expect(prisma.genericTableRow.findMany).toHaveBeenCalledWith({
         where: { tableId },
       });
+    });
+
+    it('should throw NotFoundException when table not found', async () => {
+      const tableId = '550e8400-e29b-41d4-a716-446655440099';
+      jest.spyOn(prisma.genericTable, 'findUnique').mockResolvedValueOnce(null);
+
+      await expect(service.listRows(tableId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });


### PR DESCRIPTION
This pull request updates the `run.sh` script to provide more flexibility when starting backend services. It introduces a `--no-build` option, allowing users to launch the backend and database without rebuilding Docker images, which can save time during development.

Enhancements to backend startup options:

* Added support for the `--no-build` flag when running `./run.sh backend`, so services can be started without rebuilding Docker images.
* Updated log messages to clearly indicate whether services are launched with or without rebuilding.